### PR TITLE
Update roslyn-installation.md

### DIFF
--- a/includes/roslyn-installation.md
+++ b/includes/roslyn-installation.md
@@ -22,7 +22,7 @@ Optionally, you'll also want the **DGML editor** to display graphs in the visual
 1. Run **Visual Studio Installer** 
 1. Select **Modify** 
 1. Select the **Individual components** tab 
-1. Check the box for **.NET Compiler Platform SDK**. You'll find it last under the **Compilers, build tools ,and runtimes** section.
+1. Check the box for **.NET Compiler Platform SDK**. You'll find it at the top under the **Compilers, build tools, and runtimes** section.
 
 Optionally, you'll also want the **DGML editor** to display graphs in the visualizer:
 


### PR DESCRIPTION
Corrected sentence about where to find **.NET Compiler Platform SDK**.

The **.NET Compiler Platform SDK** is at the top of the list - at least on my machines where I've tried different kinds of region settings.

![image](https://user-images.githubusercontent.com/1007631/39927270-f6186980-5531-11e8-8a44-f65905b2b606.png)
